### PR TITLE
just remove the postinstall step

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "typescript": "2.3.0"
   },
   "scripts": {
-    "postinstall": "grunt shell:webdriverUpdate",
     "test": "grunt build verify test",
     "start": "grunt develop",
     "prepush": "grunt build verify test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-sync",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Synchronous, polled selectors and expectations in Protractor 2.x",
   "homepage": "",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,7 @@ SHOULD NOT be set in selenium/protractor. Use this value instead. Default: 5 sec
 
 # Build tasks
 
+* `grunt shell:webdriverUpdate` - Install/update WebDriver
 * `npm start` - Builds the code and watches for changes
 * `npm test` - Builds the code, runs the linter and runs the test suite
 * `npm publish` - Publish a new version to NPM


### PR DESCRIPTION
Fixes #1 by just removing postinstall (people working on protractor-sync can run it manually)