### PR TITLE
Fix an issue with protractor-sync not running due to the base-dir file not being found

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -1,10 +1,6 @@
-import baseDir = require('../base_dir');
-
 export { elementSync, browserSync } from './vars';
 export { ElementFinderSync } from './element-finder-sync';
 export { BrowserSync, TargetLocatorSync, OptionsSync, WindowSync } from './browser-sync';
 export { polledExpect } from './polled-expect';
 export { configure } from './config';
 export { getActiveElement, waitForNewWindow, takeScreenshot, resizeViewport, disallowExpect, waitFor } from './utility';
-
-(() => baseDir)(); //prevent compiler error

--- a/base_dir.ts
+++ b/base_dir.ts
@@ -1,2 +1,0 @@
-//This file just exists so we get consistent output paths from the typescript compiler when doing partial compiles
-export var x: any;


### PR DESCRIPTION
Fixes an issue with protractor-sync outputting "[05:45:33] E/launcher - Error: Error: Cannot find module '../base_dir'" when trying to run.