### PR TITLE
fix innerHTML and outerHTML methods and add tests

### DIFF
--- a/app/element-finder-sync.ts
+++ b/app/element-finder-sync.ts
@@ -225,11 +225,11 @@ export class ElementFinderSync {
   }
 
   getOuterHtml(): string {
-    return this.runWithStaleDetection(() => exec(this.element.getOuterHtml()));
+    return this.runWithStaleDetection(() => exec(browserSync.executeScript('return arguments[0].outerHTML;', this.element)));
   }
 
   getInnerHtml(): string {
-    return this.runWithStaleDetection(() => exec(this.element.getInnerHtml()));
+    return this.runWithStaleDetection(() => exec(browserSync.executeScript('return arguments[0].innerHTML;', this.element)));
   }
 
   serialize(): IWebElementId {

--- a/test/spec/protractor_sync_test.ts
+++ b/test/spec/protractor_sync_test.ts
@@ -199,10 +199,10 @@ describe('Protractor extensions', () => {
       browserSync.get('data:,');
 
       appendTestArea({
-        innerHtml: '<div class="div-with-text">Some Text In The Div</div>'
+        innerHtml: '<div class="div-with-text">Some <b>HTML</b> In The Div</div>'
       });
 
-      expect(elementSync.findVisible('.div-with-text').getInnerHtml()).toBe('Some Text In The Div');
+      expect(elementSync.findVisible('.div-with-text').getInnerHtml()).toBe('Some <b>HTML</b> In The Div');
 
     }));
 

--- a/test/spec/protractor_sync_test.ts
+++ b/test/spec/protractor_sync_test.ts
@@ -193,6 +193,29 @@ describe('Protractor extensions', () => {
       el.scrollIntoView();
       expect(el.parent().scrollTop()).toEqual(500);
     }));
+
+    it('innerHTML', createTest(() => {
+      //Make sure we are starting on a fresh page
+      browserSync.get('data:,');
+
+      appendTestArea({
+        innerHtml: '<div class="div-with-text">Some Text In The Div</div>'
+      });
+
+      expect(elementSync.findVisible('.div-with-text').getInnerHtml()).toBe('Some Text In The Div');
+
+    }));
+
+    it('outerHTML', createTest(() => {
+      //Make sure we are starting on a fresh page
+      browserSync.get('data:,');
+
+      appendTestArea({
+        innerHtml: '<div class="div-with-text">Some Text In The Div</div>'
+      });
+
+      expect(elementSync.findVisible('.div-with-text').getOuterHtml()).toBe('<div class="div-with-text">Some Text In The Div</div>');
+    }));
   });
 
   describe('Element finder methods', () => {


### PR DESCRIPTION
Breaking change in Protractor 5.0.0. The Protractor syntax is a lot uglier now.

@scriby would you please take a look at this as well?