### PR TITLE
Resolve polledExpect matching regardless of element type passed in

### DIFF
--- a/app/polled-expect.ts
+++ b/app/polled-expect.ts
@@ -1,5 +1,6 @@
 import * as ab from 'asyncblock';
 import { implicitWaitMs, retryIntervalMs } from './config';
+import { exec } from './exec';
 
 export function polledExpect(func: Function, waitTimeMS?: number) {
   const timeout = waitTimeMS || implicitWaitMs;
@@ -27,7 +28,7 @@ export function polledExpect(func: Function, waitTimeMS?: number) {
       let passed = false;
 
       do {
-        const actual = func();
+        const actual = exec(func());
         const result = (<any>jasmine).matchers[key]((<any>jasmine).matchersUtil, null).compare(actual, expected);
         passed = result.pass;
 

--- a/test/spec/protractor_sync_test.ts
+++ b/test/spec/protractor_sync_test.ts
@@ -266,6 +266,12 @@ describe('Protractor extensions', () => {
         testArea.findVisible('.visible-element');
       }));
 
+      it('works with polledExpect regardless of element finder type', createTest(() => {
+        polledExpect(() => testArea.findElement('.visible-element').getElementFinder().getWebElement().isDisplayed()).toEqual(true);
+        polledExpect(() => testArea.findElement('.visible-element').isDisplayed()).toEqual(true);
+        polledExpect(() => testArea.findElement('.visible-element').getElementFinder().isDisplayed()).toEqual(true);
+      }));
+
       it('throws an error if more than one element was found', createTest(() => {
         testArea.findVisible('.duplicate-selector');
       }, 'More than one visible instance of (.duplicate-selector) was found!'));


### PR DESCRIPTION
Helps out with failures such as this (if not passing in an ElementFinder into polledExpect)

```
16:08:35 [Tests (E2E)] [chrome #01-45] Error: Expected ManagedPromise::1488967
{[[PromiseStatus]]: "pending"} to equal true.
16:08:35 [Tests (E2E)] [chrome #01-45]     at undefined.matchers.(anonymous function) [as 
toEqual] (/mnt/mesos/sandbox/ultra-ui/node_modules/protractor-sync/dist/polled-expect.js:42:31)
```