### PR TITLE
Move webdriver-manager to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=6.9.x"
   },
   "dependencies": {
-    "asyncblock": "^2.2.11",
+    "asyncblock": "^2.2.12",
     "jquery": "^2.2.4",
     "mkdirp": "0.3.0",
     "protractor": "^5.1.2"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "asyncblock": "^2.2.11",
     "jquery": "^2.2.4",
     "mkdirp": "0.3.0",
-    "protractor": "^5.1.2",
-    "webdriver-manager": "^12.0.6"
+    "protractor": "^5.1.2"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.47",
@@ -57,7 +56,8 @@
     "jasmine-spec-reporter": "2.4.0",
     "load-grunt-tasks": "3.5.2",
     "tslint": "5.2.0",
-    "typescript": "2.3.0"
+    "typescript": "2.3.0",
+    "webdriver-manager": "^12.0.6"
   },
   "scripts": {
     "test": "grunt build verify test",


### PR DESCRIPTION
Downstream clients can optionally install this if they'd like - protractor-sync doesn't use it directly at runtime.