### PR TITLE
Allow jQuery location to be configured

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -1,16 +1,20 @@
+import * as path from 'path';
+
 export let implicitWaitMs = 5000;
 export let retryIntervalMs = 10;
 export let clickRetryIntervalMs = 200;
 
 export let autoReselectStaleElements = true;
 export let autoRetryClick = true;
+export let jQueryLocation = path.join(__dirname, '../../../node_modules/jquery/dist/jquery.js');
 
 export function configure(args: {
   implicitWaitMs?: number,
   retryIntervalMs?: number,
   clickRetryIntervalMs?: number,
   autoReselectStaleElements?: boolean,
-  autoRetryClick?: boolean
+  autoRetryClick?: boolean,
+  jQueryLocation?: string
 }) {
   implicitWaitMs = args.implicitWaitMs || implicitWaitMs;
   retryIntervalMs = args.retryIntervalMs || retryIntervalMs;
@@ -18,4 +22,6 @@ export function configure(args: {
 
   autoReselectStaleElements = args.autoReselectStaleElements != null ? args.autoReselectStaleElements : autoReselectStaleElements;
   autoRetryClick = args.autoRetryClick != null ? args.autoRetryClick : autoRetryClick;
+
+  jQueryLocation = args.jQueryLocation || jQueryLocation;
 }

--- a/app/element-finder-sync.ts
+++ b/app/element-finder-sync.ts
@@ -1,11 +1,10 @@
 import * as ab from 'asyncblock';
 import * as fs from 'fs';
-import * as path from 'path';
 import { ElementFinder, Locator, ProtractorBrowser } from 'protractor';
 import { ILocation, ISize, IWebElementId, Key, WebElement } from 'selenium-webdriver';
 
 import { BrowserSync } from './browser-sync';
-import { autoRetryClick, clickRetryIntervalMs, implicitWaitMs } from './config';
+import { autoRetryClick, clickRetryIntervalMs, implicitWaitMs, jQueryLocation } from './config';
 import { exec } from './exec';
 import { polledWait } from './polled-wait';
 import { _getElements, assertElementDoesNotExist, findElement, findElements, findVisible, findVisibles  } from './selection';
@@ -319,7 +318,7 @@ export class ElementFinderSync {
     });
 
     if (!jQuery) {
-      const jquerySource = fs.readFileSync(path.join(__dirname, '../../../node_modules/jquery/dist/jquery.js'), 'utf8');
+      const jquerySource = fs.readFileSync(jQueryLocation, 'utf8');
 
       browserSync.executeScript((_jquerySource: string) => {
         /* tslint:disable-next-line:no-eval */


### PR DESCRIPTION
We're running with a bit of a non-standard environment and jQuery isn't in the location protractor-sync assumes it to be.