### PR TITLE
updates version to 5.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-sync",
-  "version": "5.2.0",
+  "version": "5.2.5",
   "description": "Protractor 5.x wrapper adding synchronous, polled selectors and expectations",
   "keywords": [
     "e2e",


### PR DESCRIPTION
I tried updating directly the tag on develop to 5.2.1.   I thought I had things updated but the package.json still had 5.2.0.  So I'm doing it the way from before.  Create a branch and PR with tags.
Sorry for the confusion!