### PR TITLE
Retry click on "Element is not clickable at point" error

### DIFF
--- a/app/element-finder-sync.ts
+++ b/app/element-finder-sync.ts
@@ -146,8 +146,10 @@ export class ElementFinderSync {
       try {
         exec(this.element.click());
       } catch (e) {
-        if (autoRetryClick && /Other element would receive the click/.test(e.message) && new Date().getTime() - startTime < implicitWaitMs) {
-          console.log('(Protractor-sync): Element (' + this.getSelectionPath() + ') was covered, retrying click.');
+        //Unfortunately there's no way to detect this except for checking the string contents.
+        const isClickError = /Element is not clickable at point/.test(e.message) || /Other element would receive the click/.test(e.message);
+        if (autoRetryClick && isClickError && new Date().getTime() - startTime < implicitWaitMs) {
+          console.log('(Protractor-sync): Element (' + this.getSelectionPath() + ') was covered or unclickable, retrying click.');
 
           const flow = ab.getCurrentFlow();
           flow.sync(setTimeout(flow.add(), clickRetryIntervalMs)); //We don't need this to retry as quickly

--- a/test/spec/protractor_sync_test.ts
+++ b/test/spec/protractor_sync_test.ts
@@ -670,7 +670,7 @@ describe('Protractor extensions', () => {
       const consoleLog = console.log;
       let count = 0;
       spyOn(console, 'log').and.callFake(function(message: any) {
-        if (/was covered, retrying click/.test(message)) {
+        if (/was covered or unclickable, retrying click/.test(message)) {
           count++;
 
           if (count === 2) {


### PR DESCRIPTION
I tried adding a test for this but couldn't figure out the condition for the error occurring. I'm currently seeing it in the wild when running some tests now though.