### PR TITLE
querySelector/querySelectorAll & executeScript element conversion

### DIFF
--- a/API.md
+++ b/API.md
@@ -122,6 +122,8 @@ The recommended approach is to call the equivalent Protractor-sync method on the
 * **getInnerHtml()** - Returns this element's innerHTML
 * **getOuterHtml()** - Returns this element's outerHTML
 * **getSelectionPath()** - Retrieves information about how the element was selected
+* **querySelector(selector)** - Selects an element within this element using the browser's native querySelector API.
+* **querySelectorAll(selector)** - Selects multiple elements within this element using the browser's native querySelectorAll API.
 * **reselect()** - Attempt to select this element again using the original selection path. Mainly used in automatic reselection.
 * **scrollIntoView()** - Scroll the page such that the top of the current element is at the top of the visible page.
 * **sendEnter()** - Convenience method to send the ENTER key to this element

--- a/app/browser-sync.ts
+++ b/app/browser-sync.ts
@@ -4,6 +4,7 @@ import { ILocation, ISize, IWebDriverOptionsCookie, Options, TargetLocator, Wind
 
 import { ElementFinderSync } from './element-finder-sync';
 import { exec } from './exec';
+import { transformElementFinderSyncToWebElementIn, transformWebElementToElementFinderSyncIn } from './utility';
 
 export class BrowserSync {
   private readonly PAUSE_DEBUGGER_DELAY_MS = 500;
@@ -17,11 +18,17 @@ export class BrowserSync {
   }
 
   executeScript<T>(script: string | Function, ...varArgs: any[]): T {
-    return exec(this.getBrowser().executeScript.apply(this.getBrowser(), arguments));
+    const transformed = transformElementFinderSyncToWebElementIn(varArgs);
+    const result = exec(this.getBrowser().executeScript.apply(this.getBrowser(), [script].concat(transformed)));
+
+    return transformWebElementToElementFinderSyncIn(result);
   }
 
   executeAsyncScript<T>(script: string | Function, ...varArgs: any[]): T {
-    return exec(this.getBrowser().executeAsyncScript.apply(this.getBrowser(), arguments));
+    const transformed = transformElementFinderSyncToWebElementIn(varArgs);
+    const result = exec(this.getBrowser().executeAsyncScript.apply(this.getBrowser(), [script].concat(transformed)));
+
+    return transformWebElementToElementFinderSyncIn(result);
   }
 
   get(destination: string, timeout?: number) {

--- a/app/element-finder-sync.ts
+++ b/app/element-finder-sync.ts
@@ -228,12 +228,31 @@ export class ElementFinderSync {
 
   //Extras
 
+  querySelector(selector: string): ElementFinderSync | undefined {
+    return this.runWithStaleDetection(() =>
+      browserSync.executeScript<ElementFinderSync | undefined>(
+        (element: HTMLElement, _selector: string) => element.querySelector(_selector), this, selector
+      )
+    ) || undefined;
+  }
+
+  querySelectorAll(selector: string): ElementFinderSync[] {
+    return this.runWithStaleDetection(() =>
+      browserSync.executeScript<ElementFinderSync[]>(
+        (element: HTMLElement, _selector: string) => element.querySelectorAll(_selector), this, selector
+    ));
+  }
+
   getOuterHtml(): string {
-    return this.runWithStaleDetection(() => exec(browserSync.executeScript('return arguments[0].outerHTML;', this.element)));
+    return this.runWithStaleDetection(() =>
+      browserSync.executeScript<string>((element: HTMLElement) => element.outerHTML, this)
+    );
   }
 
   getInnerHtml(): string {
-    return this.runWithStaleDetection(() => exec(browserSync.executeScript('return arguments[0].innerHTML;', this.element)));
+    return this.runWithStaleDetection(() =>
+      browserSync.executeScript<string>((element: HTMLElement) => element.innerHTML, this)
+    );
   }
 
   serialize(): IWebElementId {
@@ -247,7 +266,7 @@ export class ElementFinderSync {
   scrollIntoView(): ElementFinderSync {
     this.runWithStaleDetection(() => browserSync.executeScript((element: HTMLElement) => {
       element.scrollIntoView();
-    }, this.element));
+    }, this));
 
     return this;
   }
@@ -284,7 +303,7 @@ export class ElementFinderSync {
         } else {
           return result;
         }
-      }, this.element, method, arg);
+      }, this, method, arg);
     };
 
     const result = this.runWithStaleDetection(() => attempt());
@@ -294,9 +313,7 @@ export class ElementFinderSync {
     }
 
     if (Array.isArray(result)) {
-      return result.map((webElement: any, i: number) => {
-        const elementFinder = ElementFinderSync.fromWebElement_(this.element.browser_, webElement);
-
+      return result.map((elementFinder: ElementFinderSync, i: number) => {
         //TODO: clean up
         elementFinder.selectionArgs = {
           rootElement: this,
@@ -334,15 +351,15 @@ export class ElementFinderSync {
   }
 
   hasClass(className: string): boolean {
-    return this.runWithStaleDetection(() => exec(this.element.browser_.executeScript((element: HTMLElement, _className: string) => {
+    return this.runWithStaleDetection(() => browserSync.executeScript<boolean>((element: HTMLElement, _className: string) => {
       return element.classList.contains(_className);
-    }, this.element, className)));
+    }, this, className));
   }
 
   isFocused(): boolean {
-    return this.runWithStaleDetection(() => exec(this.element.browser_.executeScript((element: HTMLElement) => {
+    return this.runWithStaleDetection(() => browserSync.executeScript<boolean>((element: HTMLElement) => {
       return document.activeElement === element;
-    }, this.element)));
+    }, this));
   }
 
   innerHeight(): number {

--- a/app/utility.ts
+++ b/app/utility.ts
@@ -141,14 +141,14 @@ export function waitFor<T>(condition: () => boolean | {data: T, keepPolling: boo
   }, null, waitTimeMs);
 }
 
-export function deepCloneAndTransform(obj: any, transformer: (val: any) => any): any {
+function deepCloneAndTransform(obj: any, transformer: (val: any) => any): any {
   if (obj == null) {
     return transformer(obj);
   }
 
   if (Array.isArray(obj)) {
     return obj.map((item) => deepCloneAndTransform(item, transformer));
-  } else if (obj.constructor && (obj.constructor === Object || obj.constructor == null)) {
+  } else if (obj.constructor === Object || obj.constructor == null) {
     // Plain object
     return Object.keys(obj).reduce((clone, key) => {
       clone[key] = deepCloneAndTransform(obj[key], transformer);

--- a/test/spec/protractor_sync_test.ts
+++ b/test/spec/protractor_sync_test.ts
@@ -762,7 +762,6 @@ describe('Protractor extensions', () => {
   });
 
   describe('Browser sync', () => {
-
     it('switches to a new frame', createTest(() => {
       browserSync.get('data:,');
       appendTestArea({
@@ -771,5 +770,38 @@ describe('Protractor extensions', () => {
       browserSync.switchTo().frame(elementSync.findElement('[name="test-iframe"]'));
       elementSync.findElement('.element-outside-iframe'); // won't be found b/c we have switched to the iframe
     }, 'No instances of (.element-outside-iframe) were found'));
+  });
+
+  describe('querySelectors', () => {
+    beforeEach(createTest(() => {
+      browserSync.get('data:,');
+      appendTestArea({
+        innerHtml: '<div class="container"><div id="a" class="c1 c2">a</div><div id="b" class="c2">b</div></div>'
+      });
+    }));
+
+    it('querySelector selects an element', createTest(() => {
+      const container = elementSync.findVisible('.container');
+
+      expect(container.querySelector('.c1').getAttribute('id')).toEqual('a');
+    }));
+
+    it('querySelectorAll selects an element', createTest(() => {
+      const container = elementSync.findVisible('.container');
+
+      expect(container.querySelectorAll('.c2').map((el) => el.getAttribute('id'))).toEqual(['a', 'b']);
+    }));
+
+    it('querySelector returns undefined when element is not found', createTest(() => {
+      const container = elementSync.findVisible('.container');
+
+      expect(container.querySelector('.not-found')).toBeUndefined();
+    }));
+
+    it('querySelectorAll returns an empty array when element is not found', createTest(() => {
+      const container = elementSync.findVisible('.container');
+
+      expect(container.querySelectorAll('.not-found')).toEqual([]);
+    }));
   });
 });


### PR DESCRIPTION
Add querySelector and querySelectorAll ElementFinderSync methods.

Convert to/from selenium's WebElement class in browserSync.executeScript and browserSync.executeScriptAsync. Note that converting from WebElement to ElementFinderSync in the return value is technically a breaking change, but it seems unlikely to break user code because there wasn't a public API for converting WebElement to ElementFinderSync previously. But it's possible there's some call sites to update in the BB tests.

Increase consistency of executeScript call sites.

@mindywhitsitt the querySelector and querySelectorAll methods are kind of similar in function to the ability protractor-sync used to have for doing instant element selection. I still find that on rare occasion I have a need to do instant element selection. It typically comes up when the test doesn't have a way to know which of several possibilities are going to be on the page and it just needs to try them all and see which one it finds.

One proposal for this is this PR, which provides easy access to the browser's querySelector and querySelectorAll element methods. I think these fit in with some of the other DOM traversal APIs on ElementFinderSync. Given that they're native methods their usage should be well understood.

The fact that these aren't exposed on the main elementSync object will make it a little harder to accidentally use instead of findVisible(s)/findElement(s).

