### PR TITLE
Increases protractor-sync version to 6.0.0.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ Protractor-sync builds on Protractor and provides:
 
 Pre-reqs:
 
-* Protractor (or something like grunt-protractor-runner, which includes it)
+* Protractor 5.3 or higher (or something like grunt-protractor-runner, which includes it)
 * asyncblock (`npm install asyncblock`)
 * Jasmine (Comes with Protractor. Other frameworks can be used, but some features only work with Jasmine)
 
-Installation steps:
-
-1. `npm install protractor-sync`
+Install: `npm install protractor-sync`
 
 # Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-sync",
-  "version": "5.2.5",
+  "version": "6.0.0",
   "description": "Protractor 5.x wrapper adding synchronous, polled selectors and expectations",
   "keywords": [
     "e2e",
@@ -35,8 +35,7 @@
   "dependencies": {
     "asyncblock": "^2.2.12",
     "jquery": "3.3.1",
-    "mkdirp": "0.3.0",
-    "protractor": "^5.3.0"
+    "mkdirp": "0.3.0"
   },
   "devDependencies": {
     "@types/jasmine": "2.5.47",
@@ -55,9 +54,13 @@
     "jasmine-reporters": "2.1.1",
     "jasmine-spec-reporter": "2.4.0",
     "load-grunt-tasks": "3.5.2",
+    "protractor": "^5.3.0",
     "tslint": "5.2.0",
     "typescript": "2.3.0",
     "webdriver-manager": "^12.0.6"
+  },
+  "peerDependencies": {
+    "protractor": "^5.3.0"
   },
   "scripts": {
     "test": "grunt build verify test",


### PR DESCRIPTION
Lists protractor 5.3 and above as the minimum version in the README and as a devDependency/peerDependency