### PR TITLE
Throw an understandable error when you forget to wrap your test with an asyncblock.

### DIFF
--- a/app/selection.ts
+++ b/app/selection.ts
@@ -72,6 +72,9 @@ export function _getElements(
   }
 
   const flow = ab.getCurrentFlow();
+  if (flow == null) {
+    throw new Error('asyncblock context could not be found. Please make sure protractor-sync is being called from within an asyncblock.');
+  }
 
   return polledWait(() => {
     let elements: ElementArrayFinder;

--- a/test/spec/protractor_sync_test.ts
+++ b/test/spec/protractor_sync_test.ts
@@ -819,4 +819,12 @@ describe('Protractor extensions', () => {
       expect(container.querySelectorAll('.not-found')).toEqual([]);
     }));
   });
+
+  describe('asyncblock context error', () => {
+    it('throws an error when run outside an asyncblock context', () => {
+      expect(() => { elementSync.findVisible('body'); }).toThrowError(
+        'asyncblock context could not be found. Please make sure protractor-sync is being called from within an asyncblock.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Bonus fix!