### PR TITLE
* Give a reasonable error message when stale element reselection fails.

### DIFF
--- a/app/element-finder-sync.ts
+++ b/app/element-finder-sync.ts
@@ -448,12 +448,15 @@ export class ElementFinderSync {
         return func();
       } catch (e) {
         if (e.name === 'StaleElementReferenceError') {
-          this.element = this.reselect().getElementFinder();
+          const reselected = this.reselect();
+          if (reselected) {
+            this.element = reselected.getElementFinder();
 
-          return attempt();
-        } else {
-          throw e;
+            return attempt();
+          }
         }
+
+        throw e;
       }
     };
 

--- a/app/selection.ts
+++ b/app/selection.ts
@@ -3,6 +3,7 @@ import { ElementArrayFinder, ElementFinder, protractor, ProtractorBy } from 'pro
 
 import { autoReselectStaleElements, implicitWaitMs } from './config';
 import { ElementFinderSync } from './element-finder-sync';
+import { exec } from './exec';
 import { polledWait } from './polled-wait';
 
 /**
@@ -118,7 +119,9 @@ export function _getElements(
     if (args.requireVisible) {
       filtered = resolved.filter((element: ElementFinderSync) => {
         try {
-          return element.isDisplayed();
+          // This code uses the base protractor's isDisplayed method to avoid automatic stale element selection so
+          // stale element exceptions can be handled here instead of automatically trying to re-select.
+          return exec(element.getWebElement().isDisplayed());
         } catch (e) {
           //If the element has been removed from the DOM between when it was selected and now,
           //don't treat it as an error and fail the test.

--- a/test/spec/protractor_sync_test.ts
+++ b/test/spec/protractor_sync_test.ts
@@ -559,6 +559,13 @@ describe('Protractor extensions', () => {
         });
 
     }));
+
+    it('throws a reasonable error when the stale element cannot be reselected', createTest(() => {
+      const el = elementSync.findVisible('.stale-test-3');
+      appendTestArea({ innerHtml: '' });
+
+      expect(() => el.isDisplayed()).toThrowError('No visible instances of (.stale-test-3) were found');
+    }));
   });
 
   describe('waitFor', () => {


### PR DESCRIPTION
* If a stale element exception occurs on the visibility test for findVisible, keep polling for a stable reference.