### PR TITLE
Fix an issue with the "wait for angular enabled setting" not carrying over to new browsers

### DIFF
--- a/app/browser-sync.ts
+++ b/app/browser-sync.ts
@@ -104,6 +104,8 @@ export class BrowserSync {
     const runner = new Runner(this.getProcessedConfig());
     runner.setupGlobals_(newBrowser);
 
+    exec(newBrowser.ready);
+
     //By default the new browser will wait for angular, so we need to manually carry over the setting
     newBrowser.waitForAngularEnabled(waitForAngularEnabled);
 

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -7,6 +7,8 @@ exports.config = {
 
   // ----- How to setup Selenium -----
 
+  SELENIUM_PROMISE_MANAGER: false,
+
   // Do not start a Selenium Standalone sever - only run this using chrome.
   directConnect: true,
   chromeDriver: '../node_modules/webdriver-manager/selenium/chromedriver_'+config.webdriverComponents['chromedriver'],


### PR DESCRIPTION
Properly carry over the "wait for angular enabled setting" to newly forked browsers when running protractor tests with control flow off.