### PR TITLE
Bump jquery to more secure version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "asyncblock": "^2.2.12",
-    "jquery": "3.3.1",
+    "jquery": "3.5.0",
     "mkdirp": "0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Github was nagging that jquery has some security vulnerabilities so let's update it.

One of the tests is failing though but not sure if it is related:

```
1) Protractor extensions Window size resizes the window
  - Expected 252 to equal 200.
      at /Users/fclausen/bbgit/protractor-sync/test/spec/protractor_sync_test.ts:805:30
      at /Users/fclausen/bbgit/protractor-sync/test/spec/protractor_sync_test.ts:46:7
      at fiberContents (/Users/fclausen/bbgit/protractor-sync/node_modules/asyncblock/lib/asyncblock.js:92:26)
```

Any ideas appreciated.